### PR TITLE
Fix: Underscores apply to all hyphens when transformed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "make-it-name",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "make-it-name",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Random name generator",
     "main": "bin/program.js",
     "scripts": {

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -57,10 +57,10 @@ test('compose() should build name from adjective and scientist for even randoms'
     expect(actual.output).toBe(`${expectedAdjective}-${expectedScientist}`)
 })
 
-test('transform() should change hyphens to underscores', () => {
-    const input = 'adjective-author'
+test('transform() should change all hyphens to underscores', () => {
+    const input = 'adjective-adjective-author'
     const actual = app.transform(input)
-    expect(actual.output).toBe('adjective_author')
+    expect(actual.output).toBe('adjective_adjective_author')
 })
 
 test('transform() should handle undefined arguments', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ class App {
     }
 
     transform(input) {
-        this.output = (input || this.output).replace('-', '_')
+        this.output = (input || this.output).replace(/-/gi, '_')
         return this
     }
 


### PR DESCRIPTION
Closes #5.

Transform applies to all hyphens in the output string when transformed.